### PR TITLE
fix: Update export type for it to show correctly in file dialog

### DIFF
--- a/src/DevToolsPlugin.js
+++ b/src/DevToolsPlugin.js
@@ -15,5 +15,5 @@ export class RecorderPlugin {
 chrome.devtools.recorder.registerRecorderExtensionPlugin(
   new RecorderPlugin(),
   /* name=*/ 'Cypress Test',
-  /* mediaType=*/ 'application/javascript'
+  /* mediaType=*/ 'text/javascript'
 );


### PR DESCRIPTION
The current export file dialog doesn't append .js at the end of the file. With this fix, it will show `.js`.